### PR TITLE
CASMHMS-5608 Update internal HMS documentation for Helm CT tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-(C) Copyright [2021-2022] Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # System Layout Service (SLS)
 
-The System Layout Service (SLS) holds information about a Cray Shasta system "as configured".  That is, it contains information about how the system was designed.  SLS reflects the system if all hardware were present and working.  SLS does not keep track of hardware state or identifiers; for that type of information, see Hardware State Manager (HSM).
+The System Layout Service (SLS) holds information about a Cray Shasta system "as configured".  That is, it contains information
+about how the system was designed.  SLS reflects the system if all hardware were present and working.  SLS does not keep track
+of hardware state or identifiers; for that type of information, see Hardware State Manager (HSM).
 
 ## How it Works
 
-SLS is mostly an API to allow access to a database.  Users make queries on the basis of xname and are given back information about the system.  Each xname is matched with corresponding parent and child information, allowing the simple traversal of the entirety of the system.
+SLS is mostly an API to allow access to a database.  Users make queries on the basis of xname and are given back information
+about the system.  Each xname is matched with corresponding parent and child information, allowing the simple traversal of the
+entirety of the system.
 
 ## Configuration
 
@@ -12,9 +16,10 @@ TBD.  Initial configuration will be uploaded by an init container.
 
 ## SLS CT Testing
 
-This repository builds and publishes hms-sls-ct-test RPMs along with the service itself containing tests that verify SLS on the
-NCNs of live Shasta systems. The tests require the hms-ct-test-base RPM to also be installed on the NCNs in order to execute.
-The version of the test RPM installed on the NCNs should always match the version of SLS deployed on the system.
+In addition to the service itself, this repository builds and publishes cray-sls-test images containing tests that verify SLS
+on live Shasta systems. The tests are invoked via helm test as part of the Continuous Test (CT) framework during CSM installs
+and upgrades. The version of the cray-sls-test image (vX.Y.Z) should match the version of the cray-sls image being tested, both
+of which are specified in the helm chart for the service.
 
 ## More information
 


### PR DESCRIPTION
### Summary and Scope

- Update CT testing section of README for new Helm-based tests which replaces the former RPM-based tests.
- Assorted README cleanup.

### Issues and Related PRs

* Partially resolves CASMHMS-5608.

### Testing

- Rendered README updates and viewed them to verify that they look as expected.
- No testing performed due to documentation change only.

Was a fresh Install tested? N/A
Was an Upgrade tested? N/A
Was a Downgrade tested? N/A

### Risks and Mitigations

None, README change only.